### PR TITLE
fix deprecation warnings 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [metadata]
-description-file = README.md
+description = file: README.md
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup
-from setuptools import find_packages
+from setuptools import find_namespace_packages
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -16,7 +16,7 @@ setup(
     author='David Wright',
     author_email='dvwright@cpan.org',
     include_package_data=True,
-    packages=find_packages(
+    packages=find_namespace_packages(
         exclude=[
             'tests',
             'pyproject.toml',


### PR DESCRIPTION
fix warnings
https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#custom-discovery
and fix `SetuptoolsDeprecationWarning: Invalid dash-separated options`